### PR TITLE
Add SOR support

### DIFF
--- a/samples/batchSwaps/sampleSorSwap.json
+++ b/samples/batchSwaps/sampleSorSwap.json
@@ -1,0 +1,24 @@
+{
+  "network": "polygon",
+  "slippageTolerancePercent":"1.0", // Direct percentages (1.0 equates to 1%)
+  "sor": {
+    "sellToken":"0x2791bca1f2de4661ed88a30c99a7a9449aa84174", // token in
+    "buyToken":"0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",  // token out
+    "orderKind":"sell",       // must be "sell" or "buy" for GIVEN_IN and GIVEN_OUT respectively
+    "amount":"0.01",           // denominated as a float; automatically scaled w/ appropriate decimals 
+    
+    // Pick between queried gas price and manual gas price. Manual gas price will override if it is set.
+    "gasSpeed":"fast"         // Option 1: Query the current gas price with "slow", "average", or "fast"
+    // "gasPrice":1000000000  // Option 2: Directly set the gas price in **WEI**
+  },
+  "batchSwap": {
+    "funds": {
+      "sender": "0x7a73a786d16243680B3253a35392860eAE87d071",     // your address
+      "recipient": "0x7a73a786d16243680B3253a35392860eAE87d071",  // your address
+      "fromInternalBalance": false,   // to/from internal balance
+      "toInternalBalance": false      // set to "false" unless you know what you're doing
+    },
+    // unix timestamp after which the trade will revert if it hasn't executed yet
+    "deadline": "999999999999999999"
+  }
+}

--- a/samples/batchSwaps/sorSwapSample.py
+++ b/samples/batchSwaps/sorSwapSample.py
@@ -1,0 +1,76 @@
+import balpy
+import sys
+import os
+import jstyleson
+import json
+
+def main():
+	
+	if len(sys.argv) < 2:
+		print("Usage: python3", sys.argv[0], "/path/to/swap.json");
+		quit();
+
+	pathToSwap = sys.argv[1];
+	if not os.path.isfile(pathToSwap):
+		print("Path", pathToSwap, "does not exist. Please enter a valid path.")
+		quit();
+
+	with open(pathToSwap) as f:
+		data = jstyleson.load(f)
+
+	gasFactor = 1.05;
+	gasSpeedApproval = "fast";
+	gasSpeedTrade = "fast";
+
+
+	bal = balpy.balpy.balpy(data["network"]);
+	
+	print();
+	print("==============================================================")
+	print("============== Step 1: Query Smart Order Router ==============")
+	print("==============================================================")
+	print();
+	sor_result = bal.balSorQuery(data)
+	swap = sor_result["batchSwap"];
+
+	isFlashSwap = bal.balSwapIsFlashSwap(swap);
+
+	print();
+	print("==============================================================")
+	print("================ Step 2: Check Token Balances ================")
+	print("==============================================================")
+	print();
+	
+	tokens = swap["assets"];
+	amountsIn = swap["limits"];
+	if not isFlashSwap:
+		if not bal.erc20HasSufficientBalances(tokens, amountsIn):
+			print("Please fix your insufficient balance before proceeding.")
+			print("Quitting...")
+			quit();
+	else:
+		print("Executing Flash Swap, no token balances necessary.")
+
+
+	print();
+	print("==============================================================")
+	print("============== Step 3: Approve Token Allowance ===============")
+	print("==============================================================")
+	print();
+
+	if not isFlashSwap:
+		bal.erc20AsyncEnforceSufficientVaultAllowances(tokens, amountsIn, amountsIn, gasFactor, gasSpeedApproval);
+	else:
+		print("Executing Flash Swap, no token approvals necessary.")
+	# quit();
+
+	print();
+	print("==============================================================")
+	print("=============== Step 4: Execute Batch Swap Txn ===============")
+	print("==============================================================")
+	print();
+
+	txHash = bal.balDoBatchSwap(swap, gasFactor=gasFactor, gasPriceSpeed=gasSpeedTrade);
+	
+if __name__ == '__main__':
+	main();


### PR DESCRIPTION
Adds balpy support for the SOR via the Balancer API. PR includes sample script, and Polygon sample json

Transaction [here](https://polygonscan.com/tx/0xc32670f1014bef74523fa51fa212c8484f24ba71a3ca9e6e8e2a0baa518a5c0e) is the result of testing this script w/ a slightly modified json. 

- USDC → WMATIC
- "buy" order in SOR sent as `GIVEN_OUT` `SwapKind`
- order runs a a two hop multihop
- automatically generates limits based on a user-provided slippage tolerance and `assetDeltas` from a `queryBatchSwap()`